### PR TITLE
Add Firestore sync for achievements

### DIFF
--- a/app/schemas/com.example.habitstracker.habit.data.db.HabitDatabase/18.json
+++ b/app/schemas/com.example.habitstracker.habit.data.db.HabitDatabase/18.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 17,
+    "version": 18,
     "identityHash": "5793ce0a95631a3bd92841cc8f98703a",
     "entities": [
       {

--- a/app/src/main/java/com/example/habitstracker/di/AppModule.kt
+++ b/app/src/main/java/com/example/habitstracker/di/AppModule.kt
@@ -47,8 +47,11 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun providerLocalSyncRepository(habitDao: HabitDao): LocalSyncRepository {
-        return LocalSyncRepository(habitDao)
+    fun providerLocalSyncRepository(
+        habitDao: HabitDao,
+        historyDAO: HistoryDAO
+    ): LocalSyncRepository {
+        return LocalSyncRepository(habitDao, historyDAO)
     }
 
     @Provides

--- a/app/src/main/java/com/example/habitstracker/habit/data/db/HabitDatabase.kt
+++ b/app/src/main/java/com/example/habitstracker/habit/data/db/HabitDatabase.kt
@@ -13,7 +13,7 @@ import com.example.habitstracker.statistic.data.db.StatisticDao
 @Database(
     entities = [HabitEntity::class, DateHabitEntity::class, AchievementEntity::class, /*StatisticEntity::class*/],
     exportSchema = true,
-    version = 17
+    version = 18
 )
 abstract class HabitDatabase : RoomDatabase() {
     abstract val habitDao: HabitDao

--- a/app/src/main/java/com/example/habitstracker/habit/presentation/today_main/MainScreen.kt
+++ b/app/src/main/java/com/example/habitstracker/habit/presentation/today_main/MainScreen.kt
@@ -153,6 +153,7 @@ fun TodayScreenRoot(
                 // If there are new unlocked achievement and they are isNotified then we show a dialogue and update the data
                 if (toShow != null) {
                     val today = LocalDate.now().toString()
+                    val unlockedAchievement = toShow.copy(unlockedAt = today, isNotified = true)
                     historyViewModel.updateUnlockedDate(today, true, toShow.id)
                     historyViewModel.onAchievementUnlocked(
                         UnlockedAchievement(
@@ -162,6 +163,7 @@ fun TodayScreenRoot(
                             textPadding = AchievementMetadata.textPadding(toShow.section, context)
                         )
                     )
+                    syncViewModel.pushAchievementToCloud(unlockedAchievement)
                 }
 
                 syncViewModel.updateDateHabitOnCloud(

--- a/app/src/main/java/com/example/habitstracker/habit/presentation/today_main/MainScreen.kt
+++ b/app/src/main/java/com/example/habitstracker/habit/presentation/today_main/MainScreen.kt
@@ -132,7 +132,7 @@ fun TodayScreenRoot(
                 // 3. Find all the achievements that are now done but not notified yet
                 val newlyUnlocked = allAchievements.filter { ach ->
                     val section = AchievementSection.fromString(ach.section, context)
-                    !ach.isNotified && (metrics[section] ?: 0) >= ach.target
+                    !ach.notified && (metrics[section] ?: 0) >= ach.target
                 }
 
                 // 4.If several are one - choose one (policy: priority by section)
@@ -153,7 +153,7 @@ fun TodayScreenRoot(
                 // If there are new unlocked achievement and they are isNotified then we show a dialogue and update the data
                 if (toShow != null) {
                     val today = LocalDate.now().toString()
-                    val unlockedAchievement = toShow.copy(unlockedAt = today, isNotified = true)
+                    val unlockedAchievement = toShow.copy(unlockedAt = today, notified = true)
                     historyViewModel.updateUnlockedDate(today, true, toShow.id)
                     historyViewModel.onAchievementUnlocked(
                         UnlockedAchievement(

--- a/app/src/main/java/com/example/habitstracker/history/data/db/HistoryDAO.kt
+++ b/app/src/main/java/com/example/habitstracker/history/data/db/HistoryDAO.kt
@@ -31,7 +31,7 @@ sealed interface HistoryDAO {
     @Query("select * from achievement_table")
     fun getAllAchievement(): Flow<List<AchievementEntity>>
 
-    @Query("update achievement_table set isNotified =:isNotified, unlockedAt =:unlockedAt where id =:id")
+    @Query("update achievement_table set notified =:isNotified, unlockedAt =:unlockedAt where id =:id")
     suspend fun updateUnlockedDate(unlockedAt: String, isNotified: Boolean, id: Int)
 
 

--- a/app/src/main/java/com/example/habitstracker/history/data/db/HistoryDAO.kt
+++ b/app/src/main/java/com/example/habitstracker/history/data/db/HistoryDAO.kt
@@ -3,6 +3,7 @@ package com.example.habitstracker.history.data.db
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.example.habitstracker.habit.domain.DateHabitEntity
 import com.example.habitstracker.habit.domain.HabitEntity
@@ -12,8 +13,14 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 sealed interface HistoryDAO {
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAchievements(achievementEntityList: List<AchievementEntity>)
+
+    @Query("DELETE FROM achievement_table")
+    suspend fun clearAchievements()
+
+    @Query("select * from achievement_table")
+    suspend fun getAllAchievementsOnce(): List<AchievementEntity>
 
     @Query("select * from habit_table")
     fun getALlMyHabits(): Flow<List<HabitEntity>>

--- a/app/src/main/java/com/example/habitstracker/history/data/repository/DefaultHistoryRepository.kt
+++ b/app/src/main/java/com/example/habitstracker/history/data/repository/DefaultHistoryRepository.kt
@@ -31,8 +31,21 @@ class DefaultHistoryRepository(private val dao: HistoryDAO) : HistoryRepository 
         }
     }
 
+    override suspend fun getAllAchievementsOnce(): List<AchievementEntity> {
+        return withContext(Dispatchers.IO) {
+            dao.getAllAchievementsOnce()
+        }
+    }
+
     override fun getAllAchievements(): Flow<List<AchievementEntity>> {
         return dao.getAllAchievement()
+    }
+
+    override suspend fun replaceAchievements(achievements: List<AchievementEntity>) {
+        return withContext(Dispatchers.IO) {
+            dao.clearAchievements()
+            dao.insertAchievements(achievements)
+        }
     }
 
     override fun getAllDatesForStreak(): Flow<List<DateHabitEntity>> {

--- a/app/src/main/java/com/example/habitstracker/history/domain/AchievementEntity.kt
+++ b/app/src/main/java/com/example/habitstracker/history/domain/AchievementEntity.kt
@@ -5,11 +5,11 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "achievement_table")
 data class AchievementEntity (
-    @PrimaryKey val id: Int,
-    val section: String,  // "Habits Finished", "Perfect Days", "Best Streak"
-    val target: Int, // 1, 10, 25, 30, 100 ...
-    val unlockedAt: String, // Date when received
-    val isNotified: Boolean = false // shown a achievnotification or not
+    @PrimaryKey val id: Int = 0,
+    val section: String = "none",  // "Habits Finished", "Perfect Days", "Best Streak"
+    val target: Int = 0, // 1, 10, 25, 30, 100 ...
+    val unlockedAt: String = "none", // Date when received
+    val notified: Boolean = false // shown a achievnotification or not
 )
 
 val achievementsList: List<AchievementEntity> = listOf(

--- a/app/src/main/java/com/example/habitstracker/history/domain/HistoryRepository.kt
+++ b/app/src/main/java/com/example/habitstracker/history/domain/HistoryRepository.kt
@@ -12,7 +12,11 @@ interface HistoryRepository {
 
     suspend fun getAchievementOnce(): AchievementEntity?
 
+    suspend fun getAllAchievementsOnce(): List<AchievementEntity>
+
     fun getAllAchievements(): Flow<List<AchievementEntity>>
+
+    suspend fun replaceAchievements(achievements: List<AchievementEntity>)
 
     suspend fun updateUnlockedDate(unlockedAt: String, isNotified: Boolean, id: Int)
 

--- a/app/src/main/java/com/example/habitstracker/history/presentation/tab_screens/AchievementsScreen.kt
+++ b/app/src/main/java/com/example/habitstracker/history/presentation/tab_screens/AchievementsScreen.kt
@@ -50,7 +50,7 @@ fun AchievementsScreen(
             description = { target, index ->
                  "$target Habits Finished"
             },
-            isNotified = habitsFinished.map { it.isNotified },
+            isNotified = habitsFinished.map { it.notified },
             unlockedAt = habitsFinished.map { it.unlockedAt }
         ),
         AchievementSection(
@@ -59,7 +59,7 @@ fun AchievementsScreen(
             targets = perfectDays.map { it.target.toString() },
             progress = totalPerfectDays,
             description = { target, _ -> "$target Perfect Days" },
-            isNotified = habitsFinished.map { it.isNotified },
+            isNotified = habitsFinished.map { it.notified },
             unlockedAt = habitsFinished.map { it.unlockedAt }
         ),
         AchievementSection(
@@ -68,7 +68,7 @@ fun AchievementsScreen(
             targets = bestStreaks.map { it.target.toString() },
             progress = bestStreak,
             description = { target, _ -> "$target Days Streak" },
-            isNotified = habitsFinished.map { it.isNotified },
+            isNotified = habitsFinished.map { it.notified },
             unlockedAt = habitsFinished.map { it.unlockedAt }
         )
     )
@@ -116,28 +116,28 @@ fun AchievementsScreenPreview(modifier: Modifier = Modifier) {
             id = 1,
             section = "Habits Finished",
             target = 1,
-            isNotified = false,
+            notified = false,
             unlockedAt = "2025-01-27"
         ),
         AchievementEntity(
             id = 2,
             section = "Habits Finished",
             target = 10,
-            isNotified = false,
+            notified = false,
             unlockedAt = "2025-01-29"
         ),
         AchievementEntity(
             id = 3,
             section = "Perfect Days",
             target = 3,
-            isNotified = true,
+            notified = true,
             unlockedAt = "2025-01-28"
         ),
         AchievementEntity(
             id = 4,
             section = "Best Streak",
             target = 5,
-            isNotified = false,
+            notified = false,
             unlockedAt = "2025-01-30"
         )
     )

--- a/app/src/main/java/com/example/habitstracker/me/data/remote/CloudSyncRepository.kt
+++ b/app/src/main/java/com/example/habitstracker/me/data/remote/CloudSyncRepository.kt
@@ -3,6 +3,7 @@ package com.example.habitstracker.me.data.remote
 import android.util.Log
 import com.example.habitstracker.habit.domain.DateHabitEntity
 import com.example.habitstracker.habit.domain.HabitEntity
+import com.example.habitstracker.history.domain.AchievementEntity
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
@@ -83,6 +84,26 @@ class CloudSyncRepository @Inject constructor(private val firestore: FirebaseFir
         batch.commit().await()
     }
 
+    /** AchievementEntity */
+    suspend fun pushAchievement(userId: String, achievement: AchievementEntity) {
+        achievementsCollection(userId)
+            .document(achievement.id.toString())
+            .set(achievement)
+            .await()
+    }
+
+    suspend fun pushAchievements(userId: String, achievements: List<AchievementEntity>) {
+        val db = Firebase.firestore
+        val batch = db.batch()
+
+        val achievementsCol = achievementsCollection(userId)
+        achievements.forEach { achievement ->
+            val docRef = achievementsCol.document(achievement.id.toString())
+            batch.set(docRef, achievement)
+        }
+        batch.commit().await()
+    }
+
     suspend fun updateSelectState(
         userId: String,
         dateHabitId: String,
@@ -121,6 +142,11 @@ class CloudSyncRepository @Inject constructor(private val firestore: FirebaseFir
     suspend fun getDates(userId: String): List<DateHabitEntity> {
         val snapshot = datesCollection(userId).get().await()
         return snapshot.toObjects(DateHabitEntity::class.java)
+    }
+
+    suspend fun getAchievements(userId: String): List<AchievementEntity> {
+        val snapshot = achievementsCollection(userId).get().await()
+        return snapshot.toObjects(AchievementEntity::class.java)
     }
 
 

--- a/app/src/main/java/com/example/habitstracker/me/data/remote/CloudSyncRepository.kt
+++ b/app/src/main/java/com/example/habitstracker/me/data/remote/CloudSyncRepository.kt
@@ -85,13 +85,6 @@ class CloudSyncRepository @Inject constructor(private val firestore: FirebaseFir
     }
 
     /** AchievementEntity */
-    suspend fun pushAchievement(userId: String, achievement: AchievementEntity) {
-        achievementsCollection(userId)
-            .document(achievement.id.toString())
-            .set(achievement)
-            .await()
-    }
-
     suspend fun pushAchievements(userId: String, achievements: List<AchievementEntity>) {
         val db = Firebase.firestore
         val batch = db.batch()

--- a/app/src/main/java/com/example/habitstracker/me/domain/SyncRepository.kt
+++ b/app/src/main/java/com/example/habitstracker/me/domain/SyncRepository.kt
@@ -2,6 +2,7 @@ package com.example.habitstracker.me.domain
 
 import com.example.habitstracker.habit.domain.DateHabitEntity
 import com.example.habitstracker.habit.domain.HabitEntity
+import com.example.habitstracker.history.domain.AchievementEntity
 
 interface SyncRepository {
     suspend fun syncFromCloud(userId: String): Boolean
@@ -16,6 +17,8 @@ interface SyncRepository {
     // overloaded
     suspend fun pushDateHabitToCloud(userId: String, dateHabit: List<DateHabitEntity>): Boolean
 
+    suspend fun pushAchievementsToCloud(userId: String, achievements: List<AchievementEntity>): Boolean
+
 
     suspend fun updateHabitOnCloud(userId: String, habit: HabitEntity): Boolean
     suspend fun updateSelectStateOnCloud(userId: String, dateHabitId: String, isDone: Boolean): Boolean
@@ -24,7 +27,11 @@ interface SyncRepository {
     suspend fun clearCloud(userId: String): Boolean
     suspend fun downloadHabitsFromLocal(userId: String): List<HabitEntity>
     suspend fun downloadDatesFromLocal(userId: String): List<DateHabitEntity>
+    suspend fun downloadAchievementsFromLocal(userId: String): List<AchievementEntity>
 
     suspend fun downloadHabitsFromCloud(userId: String): List<HabitEntity>
     suspend fun downloadDatesFromCloud(userId: String): List<DateHabitEntity>
+    suspend fun downloadAchievementsFromCloud(userId: String): List<AchievementEntity>
+
+    suspend fun syncAchievementsFromCloud(userId: String): Boolean
 }

--- a/app/src/main/java/com/example/habitstracker/me/presentation/sync/SyncManager.kt
+++ b/app/src/main/java/com/example/habitstracker/me/presentation/sync/SyncManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import com.example.habitstracker.habit.domain.DateHabitEntity
 import com.example.habitstracker.habit.domain.HabitEntity
+import com.example.habitstracker.history.domain.AchievementEntity
 import com.example.habitstracker.me.domain.SyncRepository
 import com.example.habitstracker.me.presentation.sign_in.GoogleAuthUiClient
 import com.example.habitstracker.me.presentation.sign_in.isInternetAvailable
@@ -48,6 +49,16 @@ class SyncManager@Inject constructor(
         return syncRepo.pushDateHabitToCloud(user.userId, dateHabitsList)
     }
 
+    suspend fun pushAchievementToCloud(achievement: AchievementEntity): Boolean {
+        val user = googleAuthUiClient.getSignedInUser() ?: return false
+        return syncRepo.pushAchievementsToCloud(user.userId, listOf(achievement))
+    }
+
+    suspend fun pushAchievementsToCloud(achievements: List<AchievementEntity>): Boolean {
+        val user = googleAuthUiClient.getSignedInUser() ?: return false
+        return syncRepo.pushAchievementsToCloud(user.userId, achievements)
+    }
+
     suspend fun updateHabitOnCloud(habit: HabitEntity): Boolean {
         val user = googleAuthUiClient.getSignedInUser() ?: return false
         return syncRepo.updateHabitOnCloud(user.userId, habit)
@@ -78,6 +89,11 @@ class SyncManager@Inject constructor(
         return syncRepo.downloadDatesFromLocal(user.userId)
     }
 
+    suspend fun getAllLocalAchievements(): List<AchievementEntity> {
+        val user = googleAuthUiClient.getSignedInUser() ?: return emptyList()
+        return syncRepo.downloadAchievementsFromLocal(user.userId)
+    }
+
     suspend fun getAllCloudHabits(): List<HabitEntity>{
         val user = googleAuthUiClient.getSignedInUser() ?: return emptyList()
         return syncRepo.downloadHabitsFromCloud(user.userId)
@@ -86,5 +102,15 @@ class SyncManager@Inject constructor(
     suspend fun getAllCloudDates(): List<DateHabitEntity> {
         val user = googleAuthUiClient.getSignedInUser() ?: return emptyList()
         return syncRepo.downloadDatesFromCloud(user.userId)
+    }
+
+    suspend fun getAllCloudAchievements(): List<AchievementEntity> {
+        val user = googleAuthUiClient.getSignedInUser() ?: return emptyList()
+        return syncRepo.downloadAchievementsFromCloud(user.userId)
+    }
+
+    suspend fun syncAchievementsFromCloud(): Boolean {
+        val user = googleAuthUiClient.getSignedInUser() ?: return false
+        return syncRepo.syncAchievementsFromCloud(user.userId)
     }
 }

--- a/app/src/main/java/com/example/habitstracker/me/presentation/sync/SyncViewModel.kt
+++ b/app/src/main/java/com/example/habitstracker/me/presentation/sync/SyncViewModel.kt
@@ -3,6 +3,7 @@ package com.example.habitstracker.me.presentation.sync
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.habitstracker.habit.domain.HabitEntity
+import com.example.habitstracker.history.domain.AchievementEntity
 import com.example.habitstracker.me.data.local.SyncPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
@@ -65,6 +66,13 @@ class SyncViewModel @Inject constructor(
         }
     }
 
+    fun pushAchievementToCloud(achievement: AchievementEntity) {
+        viewModelScope.launch {
+            if (internetAvailable() == false) return@launch
+            syncManager.pushAchievementToCloud(achievement)
+        }
+    }
+
     fun updateHabitOnCloud(habit: HabitEntity) {
         viewModelScope.launch {
             if (internetAvailable() == false) return@launch
@@ -100,6 +108,7 @@ class SyncViewModel @Inject constructor(
         viewModelScope.launch {
             val localHabits = syncManager.getAllLocalHabits()
             val localDates = syncManager.getAllLocalDates()
+            val localAchievements = syncManager.getAllLocalAchievements()
 
             /*val cloudHabits = syncManager.getAllCloudHabits()
             val cloudDates = syncManager.getAllCloudDates()*/
@@ -107,6 +116,7 @@ class SyncViewModel @Inject constructor(
             // push missing habits
             syncManager.pushHabitToCloud(localHabits)
             syncManager.pushDateHabitToCloud(localDates)
+            syncManager.pushAchievementsToCloud(localAchievements)
             _state.update { it.copy(lastSync = updateLastSync()) }
         }
     }


### PR DESCRIPTION
## Summary
- add Firestore push and fetch operations for achievements
- extend local repositories and sync flow to include achievements in cloud sync
- trigger pushing unlocked achievements when they are awarded